### PR TITLE
feat: modernize layout for scrollable UI

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -16,9 +16,9 @@ export default function App() {
   const { me, logout } = useAuth();
 
   return (
-    <main style={{ padding: 24, maxWidth: 1100, margin: '0 auto' }}>
-      <header style={{ display: 'flex', gap: 16, alignItems: 'center', marginBottom: 24 }}>
-        <h2 style={{ marginRight: 'auto' }}>MMTC</h2>
+    <div className="app-container">
+      <header className="app-header">
+        <h2>MMTC</h2>
         <Link to="/">Home</Link>
         <Link to="/helpers">Helpers</Link>
         <Link to="/myleads">My Leads</Link>
@@ -36,26 +36,28 @@ export default function App() {
         )}
       </header>
 
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/helpers" element={<Helpers />} />
-        <Route path="/helpers/:id" element={<HelperDetail />} />
-        <Route path="/myleads" element={<MyLeads />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/signup" element={<Signup />} />
+      <main className="app-content">
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/helpers" element={<Helpers />} />
+          <Route path="/helpers/:id" element={<HelperDetail />} />
+          <Route path="/myleads" element={<MyLeads />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/signup" element={<Signup />} />
 
-        <Route
-          path="/admin"
-          element={
-            <AdminRoute>
-              <Dashboard />
-            </AdminRoute>
-          }
-        >
-          <Route path="helpers" element={<HelpersAdmin />} />
-        </Route>
-      </Routes>
-      <WhatsAppButton />
-    </main>
+          <Route
+            path="/admin"
+            element={
+              <AdminRoute>
+                <Dashboard />
+              </AdminRoute>
+            }
+          >
+            <Route path="helpers" element={<HelpersAdmin />} />
+          </Route>
+        </Routes>
+        <WhatsAppButton />
+      </main>
+    </div>
   );
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,68 +1,53 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+/* Global styles for a modern, scroll-friendly layout */
+html, body, #root {
+  height: 100%;
 }
 
 body {
   margin: 0;
+  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  background: #f5f5f5;
+  color: #333;
+}
+
+a {
+  color: #0d6efd;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.app-container {
+  height: 100%;
   display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
+  flex-direction: column;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  padding: 12px 24px;
+  background: #fff;
+  border-bottom: 1px solid #ddd;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+.app-header h2 {
+  margin: 0;
+  margin-right: auto;
+  font-size: 1.25rem;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+.app-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px;
+  max-width: 1100px;
+  width: 100%;
+  margin: 0 auto;
 }

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.jsx';
 import { AuthProvider } from './auth.jsx';
+import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <BrowserRouter>


### PR DESCRIPTION
## Summary
- restructure layout with sticky header and scrollable content
- centralize global styles for modern look and light theme
- load global CSS in main entry point

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6a19db90c832880a8aa2ae3906f0d