### PR TITLE
Add email verification to signup flow

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,6 +4,7 @@ import Helpers from './pages/Helpers.jsx';
 import HelperDetail from './pages/HelperDetail.jsx';
 import Login from './pages/Login.jsx';
 import Signup from './pages/Signup.jsx';
+import Verify from './pages/Verify.jsx';
 import { useAuth } from './auth.jsx';
 import MyLeads from './pages/MyLeads.jsx';
 
@@ -44,6 +45,7 @@ export default function App() {
           <Route path="/myleads" element={<MyLeads />} />
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<Signup />} />
+          <Route path="/verify" element={<Verify />} />
 
           <Route
             path="/admin"

--- a/client/src/pages/Signup.jsx
+++ b/client/src/pages/Signup.jsx
@@ -1,7 +1,5 @@
 import { useState } from 'react';
 import api from '../api';
-import { useAuth } from '../auth';
-import { useNavigate } from 'react-router-dom';
 
 export default function Signup() {
     const [name, setName] = useState('');
@@ -9,16 +7,14 @@ export default function Signup() {
     const [phone, setPhone] = useState('');
     const [password, setPassword] = useState('');
     const [err, setErr] = useState('');
-    const nav = useNavigate();
-    const { login } = useAuth();
+    const [sent, setSent] = useState(false);
 
     async function submit(e) {
         e.preventDefault();
         setErr('');
         try {
-            const { data } = await api.post('/auth/register', { name, email, phone, password });
-            login(data.token);
-            nav('/helpers');
+            await api.post('/auth/register', { name, email, phone, password });
+            setSent(true);
         } catch (e) {
             setErr(e?.response?.data?.error || 'Signup failed');
         }
@@ -32,7 +28,11 @@ export default function Signup() {
             <input placeholder="Phone (optional)" value={phone} onChange={e => setPhone(e.target.value)} />
             <input type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
             {err && <p style={{ color: 'crimson' }}>{err}</p>}
-            <button type="submit">Sign up</button>
+            {sent ? (
+                <p style={{ color: 'green' }}>Check your email to verify your account.</p>
+            ) : (
+                <button type="submit">Sign up</button>
+            )}
         </form>
     );
 }

--- a/client/src/pages/Verify.jsx
+++ b/client/src/pages/Verify.jsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import api from '../api';
+
+export default function Verify() {
+    const [params] = useSearchParams();
+    const [msg, setMsg] = useState('Verifying...');
+
+    useEffect(() => {
+        const token = params.get('token');
+        if (!token) {
+            setMsg('Missing token');
+            return;
+        }
+        api.get(`/auth/verify?token=${token}`)
+            .then(() => setMsg('Email verified! You can now log in.'))
+            .catch(() => setMsg('Verification failed'));
+    }, [params]);
+
+    return <p>{msg}</p>;
+}

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -6,7 +6,9 @@ const UserSchema = new Schema({
     name: { type: String, required: true, trim: true },
     email: { type: String, required: true, unique: true, lowercase: true, trim: true },
     phone: { type: String, trim: true },
-    passwordHash: { type: String, required: true }
+    passwordHash: { type: String, required: true },
+    verified: { type: Boolean, default: false },
+    verificationToken: { type: String }
 }, { timestamps: true });
 
 UserSchema.methods.setPassword = async function (pw) {


### PR DESCRIPTION
## Summary
- Require email verification for new accounts
- Add verification endpoint and optional email sender
- Add verify page and update signup flow

## Testing
- `npm test` (server) *(fails: Missing script "test")*
- `npm test` (client) *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a6a6b898388328808acea3e841d548