### PR TITLE
feat: add AI chat assistant

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -12,6 +12,7 @@ import AdminRoute from './components/adminRoute.jsx';
 import Dashboard from './pages/admin/Dashboard.jsx';
 import HelpersAdmin from './pages/admin/HelpersAdmin.jsx';
 import WhatsAppButton from './components/WhatsAppButton.jsx';
+import ChatWidget from './components/ChatWidget.jsx';
 
 export default function App() {
   const { me, logout } = useAuth();
@@ -59,6 +60,7 @@ export default function App() {
           </Route>
         </Routes>
         <WhatsAppButton />
+        <ChatWidget />
       </main>
     </div>
   );

--- a/client/src/components/ChatWidget.css
+++ b/client/src/components/ChatWidget.css
@@ -1,0 +1,40 @@
+.chat-toggle {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 1000;
+}
+
+.chat-box {
+  position: fixed;
+  bottom: 70px;
+  right: 20px;
+  width: 300px;
+  background: #fff;
+  border: 1px solid #ccc;
+  display: flex;
+  flex-direction: column;
+  z-index: 1000;
+}
+
+.chat-messages {
+  flex: 1;
+  padding: 10px;
+  overflow-y: auto;
+}
+
+.chat-input {
+  display: flex;
+}
+
+.chat-input input {
+  flex: 1;
+}
+
+.msg.user {
+  text-align: right;
+}
+
+.msg.bot {
+  text-align: left;
+}

--- a/client/src/components/ChatWidget.jsx
+++ b/client/src/components/ChatWidget.jsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import api from '../api';
+import './ChatWidget.css';
+
+export default function ChatWidget() {
+  const [open, setOpen] = useState(false);
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+
+  const send = async () => {
+    if (!input.trim()) return;
+    const userText = input;
+    setMessages(m => [...m, { from: 'user', text: userText }]);
+    setInput('');
+    try {
+      const res = await api.post('/chat', { message: userText });
+      const { helpers, explanation } = res.data;
+      const helperLines = helpers.map(h => `${h.name} (${h.nationality}) - ${h.skills.join(', ')}`).join('\n');
+      const reply = `${explanation}\n\n${helperLines}`;
+      setMessages(m => [...m, { from: 'bot', text: reply }]);
+    } catch {
+      setMessages(m => [...m, { from: 'bot', text: 'Sorry, I could not get recommendations.' }]);
+    }
+  };
+
+  return (
+    <div>
+      <button className="chat-toggle" onClick={() => setOpen(o => !o)}>
+        {open ? 'Close' : 'Chat'}
+      </button>
+      {open && (
+        <div className="chat-box">
+          <div className="chat-messages">
+            {messages.map((m, i) => (
+              <div key={i} className={`msg ${m.from}`}>{m.text}</div>
+            ))}
+          </div>
+          <div className="chat-input">
+            <input
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && send()}
+              placeholder="Tell me your requirements..."
+            />
+            <button onClick={send}>Send</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,7 @@
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.4.0",
-    "multer": "^2.0.2"
+    "multer": "^2.0.2",
+    "openai": "^4.0.0"
   }
 }

--- a/server/routes/chat.js
+++ b/server/routes/chat.js
@@ -1,0 +1,50 @@
+const express = require('express');
+const OpenAI = require('openai');
+const Helper = require('../models/Helper');
+
+const router = express.Router();
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+router.post('/', async (req, res) => {
+    const { message } = req.body;
+    if (!message) return res.status(400).json({ error: 'Message is required' });
+
+    try {
+        const analysis = await openai.responses.create({
+            model: 'gpt-4.1-mini',
+            input: `Extract helper search criteria from the following user message and respond as JSON with keys: nationality, minAge, maxAge, minExperience, skills (array). If not specified, use null.\n\n${message}`
+        });
+        let filters = {};
+        try {
+            filters = JSON.parse(analysis.output_text);
+        } catch {
+            filters = {};
+        }
+
+        const query = {};
+        if (filters.nationality) query.nationality = new RegExp(filters.nationality, 'i');
+        if (filters.minAge || filters.maxAge) query.age = {};
+        if (filters.minAge) query.age.$gte = filters.minAge;
+        if (filters.maxAge) query.age.$lte = filters.maxAge;
+        if (filters.minExperience) query.experience = { $gte: filters.minExperience };
+        if (filters.skills && filters.skills.length) {
+            query.skills = { $all: filters.skills.map(s => new RegExp(s, 'i')) };
+        }
+
+        const helpers = await Helper.find(query).limit(3).lean();
+
+        const summary = helpers.map(h => `${h.name}, ${h.age} years old ${h.nationality}, skills: ${h.skills.join(', ')}`).join('\n');
+        const explanationRes = await openai.responses.create({
+            model: 'gpt-4.1-mini',
+            input: `User request: ${message}\n\nHelpers:\n${summary}\n\nExplain concisely why these helpers match the request.`
+        });
+
+        res.json({ helpers, explanation: explanationRes.output_text });
+    } catch (err) {
+        console.error(err);
+        res.status(500).json({ error: 'Failed to get recommendation' });
+    }
+});
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -16,6 +16,7 @@ app.use('/api/helpers', require('./routes/helpers'));
 app.use('/api/leads', require('./routes/leads'));
 app.use('/api/jobs', require('./routes/jobs'));
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
+app.use('/api/chat', require('./routes/chat'));
 
 // 👉 add this:
 app.use('/api/admin', require('./routes/admin'));


### PR DESCRIPTION
## Summary
- integrate OpenAI-powered chat endpoint that parses user needs and queries MongoDB helpers
- add floating React chat widget calling the new API and displaying recommended helpers

## Testing
- `cd server && npm test`
- `cd client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad5cab9d3c832890ed7e9162ae0eaa