### PR TITLE
feat: add streaming chat responses

### DIFF
--- a/client/src/components/ChatWidget.css
+++ b/client/src/components/ChatWidget.css
@@ -55,12 +55,31 @@
   border-radius: 0 0 8px 0;
 }
 
-.msg.user {
-  text-align: right;
+.msg {
   margin: 4px 0;
+  display: flex;
+}
+
+.msg.user {
+  justify-content: flex-end;
 }
 
 .msg.bot {
-  text-align: left;
-  margin: 4px 0;
+  justify-content: flex-start;
+}
+
+.msg .bubble {
+  padding: 8px 12px;
+  border-radius: 16px;
+  max-width: 80%;
+}
+
+.msg.user .bubble {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.msg.bot .bubble {
+  background: #eee;
+  color: #333;
 }


### PR DESCRIPTION
## Summary
- stream chat replies from server and fall back to general assistant when message isn't about helpers
- show chat replies in bubble wrappers with live updating text

## Testing
- ⚠️ `npm test` (fails: `/usr/bin/npm: No such file or directory`)
- ⚠️ `npm run lint` (fails: `/usr/bin/npm: No such file or directory`)


------
https://chatgpt.com/codex/tasks/task_e_68ae991ca088832882247f43435f0dc9