### PR TITLE
fix: constrain chat widget height

### DIFF
--- a/client/src/components/ChatWidget.css
+++ b/client/src/components/ChatWidget.css
@@ -20,6 +20,7 @@
   bottom: 80px;
   right: 20px;
   width: 320px;
+  height: 400px;
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: 8px;


### PR DESCRIPTION
## Summary
- keep chat widget a fixed size so messages scroll within the box

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aeae93c338832881eeed00dc616012