### PR TITLE
fix: improve floating action button layout

### DIFF
--- a/client/src/components/ChatWidget.css
+++ b/client/src/components/ChatWidget.css
@@ -1,6 +1,6 @@
 .chat-toggle {
   position: fixed;
-  bottom: 20px;
+  bottom: 80px;
   right: 20px;
   z-index: 1000;
   background: var(--color-primary);
@@ -17,7 +17,7 @@
 
 .chat-box {
   position: fixed;
-  bottom: 80px;
+  bottom: 140px;
   right: 20px;
   width: 320px;
   height: 400px;
@@ -83,4 +83,17 @@
 .msg.bot .bubble {
   background: #eee;
   color: #333;
+}
+
+@media (max-width: 600px) {
+  .chat-toggle {
+    right: 16px;
+    bottom: 80px;
+  }
+
+  .chat-box {
+    right: 16px;
+    bottom: 140px;
+    width: calc(100% - 32px);
+  }
 }

--- a/client/src/components/WhatsAppButton.css
+++ b/client/src/components/WhatsAppButton.css
@@ -1,7 +1,7 @@
 .whatsapp-button {
   position: fixed;
   bottom: 20px;
-  right: 100px;
+  right: 20px;
   width: 56px;
   height: 56px;
   background-color: #25d366;


### PR DESCRIPTION
## Summary
- reposition chat widget and WhatsApp button to avoid overlap
- add responsive styles so buttons align on mobile

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aeb0cf86048328b054c08bcef3c071