### PR TITLE
Add password reset feature

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -5,6 +5,8 @@ import HelperDetail from './pages/HelperDetail.jsx';
 import Login from './pages/Login.jsx';
 import Signup from './pages/Signup.jsx';
 import Verify from './pages/Verify.jsx';
+import ForgotPassword from './pages/ForgotPassword.jsx';
+import ResetPassword from './pages/ResetPassword.jsx';
 import { useAuth } from './auth.jsx';
 import MyLeads from './pages/MyLeads.jsx';
 
@@ -48,6 +50,8 @@ export default function App() {
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<Signup />} />
           <Route path="/verify" element={<Verify />} />
+          <Route path="/forgot-password" element={<ForgotPassword />} />
+          <Route path="/reset-password" element={<ResetPassword />} />
 
           <Route
             path="/admin"

--- a/client/src/pages/ForgotPassword.jsx
+++ b/client/src/pages/ForgotPassword.jsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import api from '../api';
+
+export default function ForgotPassword() {
+  const [email, setEmail] = useState('');
+  const [msg, setMsg] = useState('');
+
+  async function submit(e) {
+    e.preventDefault();
+    setMsg('');
+    try {
+      await api.post('/auth/forgot-password', { email });
+      setMsg('If the email exists, a reset link has been sent.');
+    } catch (e) {
+      setMsg(e?.response?.data?.error || 'Request failed');
+    }
+  }
+
+  return (
+    <form onSubmit={submit} style={{ maxWidth: 360 }}>
+      <h1>Forgot Password</h1>
+      <input
+        type="email"
+        placeholder="Email"
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+      />
+      {msg && <p>{msg}</p>}
+      <button type="submit">Send reset link</button>
+    </form>
+  );
+}

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import api from '../api';
 import { useAuth } from '../auth';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 
 export default function Login() {
     const [email, setEmail] = useState('');
@@ -29,6 +29,7 @@ export default function Login() {
             <input type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
             {err && <p style={{ color: 'crimson' }}>{err}</p>}
             <button type="submit">Login</button>
+            <p><Link to="/forgot-password">Forgot password?</Link></p>
         </form>
     );
 }

--- a/client/src/pages/ResetPassword.jsx
+++ b/client/src/pages/ResetPassword.jsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import api from '../api';
+
+export default function ResetPassword() {
+  const [params] = useSearchParams();
+  const token = params.get('token') || '';
+  const [password, setPassword] = useState('');
+  const [msg, setMsg] = useState('');
+  const nav = useNavigate();
+
+  async function submit(e) {
+    e.preventDefault();
+    setMsg('');
+    try {
+      await api.post('/auth/reset-password', { token, password });
+      setMsg('Password reset successful. Redirecting to login...');
+      setTimeout(() => nav('/login'), 1500);
+    } catch (e) {
+      setMsg(e?.response?.data?.error || 'Reset failed');
+    }
+  }
+
+  if (!token) return <p>Invalid reset token.</p>;
+
+  return (
+    <form onSubmit={submit} style={{ maxWidth: 360 }}>
+      <h1>Reset Password</h1>
+      <input
+        type="password"
+        placeholder="New password"
+        value={password}
+        onChange={e => setPassword(e.target.value)}
+      />
+      {msg && <p>{msg}</p>}
+      <button type="submit">Reset Password</button>
+    </form>
+  );
+}

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -12,6 +12,10 @@ const UserSchema = new mongoose.Schema({
     // email verification
     verified: { type: Boolean, default: false },
     verificationToken: { type: String, default: null },
+
+    // password reset
+    passwordResetToken: { type: String, default: null },
+    passwordResetExpires: { type: Date, default: null },
 }, { timestamps: true });
 
 UserSchema.methods.setPassword = async function (password) {

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -31,6 +31,28 @@ async function sendVerification(email, token) {
     console.log('Verification email:', nodemailer.getTestMessageUrl(info));
 }
 
+async function sendPasswordReset(email, token) {
+    const url = `http://localhost:5173/reset-password?token=${token}`;
+    if (!nodemailer) {
+        console.log('Reset at:', url);
+        return;
+    }
+    const testAccount = await nodemailer.createTestAccount();
+    const transporter = nodemailer.createTransport({
+        host: 'smtp.ethereal.email',
+        port: 587,
+        auth: { user: testAccount.user, pass: testAccount.pass }
+    });
+    const info = await transporter.sendMail({
+        from: 'no-reply@example.com',
+        to: email,
+        subject: 'Reset your password',
+        html: `<a href="${url}">Reset Password</a>`,
+        text: `Reset your password: ${url}`
+    });
+    console.log('Password reset email:', nodemailer.getTestMessageUrl(info));
+}
+
 function sign(u) {
     const secret = process.env.JWT_SECRET || 'change_me';
     return jwt.sign({ id: u._id, name: u.name, email: u.email, role: u.role }, secret, { expiresIn: '7d' });
@@ -61,6 +83,36 @@ router.post('/login', async (req, res) => {
         return res.status(403).json({ error: 'Email not verified' });
     }
     res.json({ token: sign(u) });
+});
+
+// POST /api/auth/forgot-password
+router.post('/forgot-password', async (req, res) => {
+    const { email } = req.body || {};
+    if (!email) return res.status(400).json({ error: 'Email is required' });
+    const u = await User.findOne({ email });
+    if (!u) return res.json({ message: 'If the email exists, a reset link has been sent' });
+    const token = crypto.randomBytes(32).toString('hex');
+    u.passwordResetToken = token;
+    u.passwordResetExpires = new Date(Date.now() + 1000 * 60 * 60); // 1 hour
+    await u.save();
+    await sendPasswordReset(email, token);
+    res.json({ message: 'If the email exists, a reset link has been sent' });
+});
+
+// POST /api/auth/reset-password
+router.post('/reset-password', async (req, res) => {
+    const { token, password } = req.body || {};
+    if (!token || !password) return res.status(400).json({ error: 'Missing token or password' });
+    const u = await User.findOne({
+        passwordResetToken: token,
+        passwordResetExpires: { $gt: new Date() }
+    });
+    if (!u) return res.status(400).json({ error: 'Invalid or expired token' });
+    await u.setPassword(password);
+    u.passwordResetToken = undefined;
+    u.passwordResetExpires = undefined;
+    await u.save();
+    res.json({ message: 'Password reset successful' });
 });
 
 // GET /api/auth/me


### PR DESCRIPTION
## Summary
- allow users to request password reset and set new password
- add frontend pages for requesting and completing password reset

## Testing
- `npm test --prefix server` (fails: Missing script "test")
- `npm test --prefix client` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68afd7f5b9048328beaa7e574eb29c09