### PR TITLE
Add bubble selection for helper search vs MDW policy

### DIFF
--- a/client/src/components/ChatWidget.css
+++ b/client/src/components/ChatWidget.css
@@ -36,6 +36,21 @@
   overflow-y: auto;
 }
 
+.bubble-options {
+  display: flex;
+  gap: 8px;
+  margin: 8px 0;
+}
+
+.bubble-options button {
+  border: none;
+  padding: 6px 12px;
+  border-radius: 16px;
+  background: var(--color-primary);
+  color: #fff;
+  cursor: pointer;
+}
+
 .chat-input {
   display: flex;
   border-top: 1px solid var(--color-border);

--- a/client/src/components/ChatWidget.jsx
+++ b/client/src/components/ChatWidget.jsx
@@ -4,9 +4,26 @@ import './ChatWidget.css';
 
 export default function ChatWidget() {
   const [open, setOpen] = useState(false);
-  const [messages, setMessages] = useState([]);
+  const [messages, setMessages] = useState([
+    { from: 'bot', text: 'What do you need help with?' }
+  ]);
   const [input, setInput] = useState('');
+  const [mode, setMode] = useState(null); // 'helper' or 'policy'
   const baseURL = api.defaults.baseURL;
+
+  const selectMode = m => {
+    setMode(m);
+    const label = m === 'helper' ? 'Hiring helper' : 'MDW policy';
+    const prompt =
+      m === 'helper'
+        ? 'Please tell me your helper requirements.'
+        : 'Ask your MDW policy question.';
+    setMessages(msgs => [
+      ...msgs,
+      { from: 'user', text: label },
+      { from: 'bot', text: prompt }
+    ]);
+  };
 
   const send = async () => {
     if (!input.trim()) return;
@@ -17,7 +34,7 @@ export default function ChatWidget() {
       const res = await fetch(`${baseURL}/chat`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message: userText })
+        body: JSON.stringify({ message: userText, mode })
       });
       const reader = res.body.getReader();
       const decoder = new TextDecoder();
@@ -46,26 +63,38 @@ export default function ChatWidget() {
       <button className="chat-toggle" onClick={() => setOpen(o => !o)}>
         {open ? 'Close' : 'Chat'}
       </button>
-      {open && (
-        <div className="chat-box">
-          <div className="chat-messages">
-            {messages.map((m, i) => (
-              <div key={i} className={`msg ${m.from}`}>
-                <div className="bubble">{m.text}</div>
+        {open && (
+          <div className="chat-box">
+            <div className="chat-messages">
+              {messages.map((m, i) => (
+                <div key={i} className={`msg ${m.from}`}>
+                  <div className="bubble">{m.text}</div>
+                </div>
+              ))}
+              {!mode && (
+                <div className="bubble-options">
+                  <button onClick={() => selectMode('helper')}>Hiring helper</button>
+                  <button onClick={() => selectMode('policy')}>MDW policy</button>
+                </div>
+              )}
+            </div>
+            {mode && (
+              <div className="chat-input">
+                <input
+                  value={input}
+                  onChange={e => setInput(e.target.value)}
+                  onKeyDown={e => e.key === 'Enter' && send()}
+                  placeholder={
+                    mode === 'helper'
+                      ? 'Tell me your requirements...'
+                      : 'Ask about MDW policy...'
+                  }
+                />
+                <button onClick={send}>Send</button>
               </div>
-            ))}
+            )}
           </div>
-          <div className="chat-input">
-            <input
-              value={input}
-              onChange={e => setInput(e.target.value)}
-              onKeyDown={e => e.key === 'Enter' && send()}
-              placeholder="Tell me your requirements..."
-            />
-            <button onClick={send}>Send</button>
-          </div>
-        </div>
-      )}
+        )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Accept a `mode` flag in the chat API to route between helper search and MDW policy handling
- Present initial bubble options in the chat widget so users choose hiring helper or MDW policy
- Style chat widget bubble option buttons

## Testing
- `npm test` (server) *(fails: Missing script: "test")*
- `npm test` (client) *(fails: Missing script: "test")*
- `npm run lint` (client)

------
https://chatgpt.com/codex/tasks/task_e_68b00ca4f42083288b5a9acb9150942c