### PR TITLE
feat: show shortlisted helpers in My Leads

### DIFF
--- a/client/src/pages/MyLeads.jsx
+++ b/client/src/pages/MyLeads.jsx
@@ -1,19 +1,52 @@
 import { useEffect, useState } from 'react';
 import api from '../api';
+import HelperCard from '../components/HelperCard';
+import useShortlist from '../hooks/useShortlist.jsx';
 
 export default function MyLeads() {
     const [items, setItems] = useState([]);
+    const [shortlist, setShortlist] = useState([]);
     const [err, setErr] = useState('');
+    const { toggle } = useShortlist();
 
     useEffect(() => {
         api.get('/leads/my')
             .then(r => setItems(r.data))
             .catch(e => setErr(e?.response?.data?.error || 'Failed to load'));
+
+        api.get('/jobs/active/shortlist')
+            .then(r => setShortlist(r.data.shortlist || []))
+            .catch(() => {});
     }, []);
 
     if (err) return <p style={{ color: 'crimson' }}>{err}</p>;
     return (
         <>
+            <h1>My Shortlisted Helpers</h1>
+            {shortlist.length === 0 && <p>No shortlisted helpers yet.</p>}
+            <div style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))',
+                gap: 16,
+                marginBottom: 32
+            }}>
+                {shortlist.map(h => (
+                    <HelperCard
+                        key={h._id}
+                        h={h}
+                        shortlisted
+                        onToggle={async (id) => {
+                            try {
+                                await toggle(id);
+                                setShortlist(prev => prev.filter(x => x._id !== id));
+                            } catch (e) {
+                                alert(e.message || 'Failed');
+                            }
+                        }}
+                    />
+                ))}
+            </div>
+
             <h1>My Interview Requests</h1>
             {items.length === 0 && <p>No leads yet.</p>}
             <div style={{ display: 'grid', gap: 12 }}>


### PR DESCRIPTION
## Summary
- display shortlisted helpers on the My Leads page
- allow removing helpers from shortlist from My Leads

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b054ebee8c832891ad8cbabed4ec34