### PR TITLE
feat: enable helper editing with photo management

### DIFF
--- a/client/src/pages/admin/HelperForm.jsx
+++ b/client/src/pages/admin/HelperForm.jsx
@@ -103,6 +103,23 @@ export default function HelperForm({ helperId, onSaved }) {
         });
     }
 
+    // Remove an existing (already uploaded) photo
+    async function removeExistingPhoto(index) {
+        if (!isEdit) return;
+        const url = form.photos[index];
+        if (!url) return;
+        try {
+            await api.delete(`/admin/helpers/${helperId}/photos`, { data: { url } });
+            setForm(prev => ({
+                ...prev,
+                photos: prev.photos.filter((_, i) => i !== index),
+            }));
+        } catch (err) {
+            console.error(err);
+            alert('Remove failed');
+        }
+    }
+
     async function handleSubmit(e) {
         e.preventDefault();
         setLoading(true);
@@ -272,13 +289,24 @@ export default function HelperForm({ helperId, onSaved }) {
                     <div className="flex gap-2 flex-wrap">
                         {existingPhotoUrls.length > 0 ? (
                             existingPhotoUrls.map((url, idx) => (
-                                <img
-                                    key={`ex-${idx}`}
-                                    src={url}
-                                    alt=""
-                                    className="w-24 h-24 object-cover rounded border"
-                                    onError={(e) => { e.currentTarget.src = PLACEHOLDER; }}
-                                />
+                                <div key={`ex-${idx}`} className="relative">
+                                    <img
+                                        src={url}
+                                        alt=""
+                                        className="w-24 h-24 object-cover rounded border"
+                                        onError={(e) => { e.currentTarget.src = PLACEHOLDER; }}
+                                    />
+                                    {isEdit && (
+                                        <button
+                                            type="button"
+                                            onClick={() => removeExistingPhoto(idx)}
+                                            className="absolute -top-2 -right-2 bg-white border border-gray-300 rounded-full w-6 h-6 text-xs leading-5 hover:bg-gray-50"
+                                            title="Remove"
+                                        >
+                                            ×
+                                        </button>
+                                    )}
+                                </div>
                             ))
                         ) : (
                             <img

--- a/client/src/pages/admin/HelpersAdmin.jsx
+++ b/client/src/pages/admin/HelpersAdmin.jsx
@@ -3,29 +3,34 @@ import { useEffect, useState } from 'react';
 import api from '../../api';
 import HelperForm from './HelperForm.jsx';
 
+// Admin page for managing helpers with create/edit capabilities
 export default function HelpersAdmin() {
     const [q, setQ] = useState('');
     const [status, setStatus] = useState('');
     const [items, setItems] = useState([]);
-    const [msg, setMsg] = useState('');
-    const [openForm, setOpenForm] = useState(false);
-    const [editing, setEditing] = useState(null);
-
-    // 🔢 pagination state
-    const [page, setPage] = useState(1);
-    const [limit, setLimit] = useState(20);
     const [meta, setMeta] = useState({ page: 1, pages: 1, total: 0, limit: 20 });
     const [loading, setLoading] = useState(false);
+    const [msg, setMsg] = useState('');
+
+    // Modal/form state
+    // undefined = closed, null = creating, string = editing id
+    const [openId, setOpenId] = useState(undefined);
+    const [refreshKey, setRefreshKey] = useState(0); // force re-mount of form
+
+    const page = meta.page || 1;
+    const limit = meta.limit || 20;
+    const canPrev = page > 1;
+    const canNext = page < (meta.pages || 1);
 
     async function load(p = page, l = limit) {
-        setMsg('');
         setLoading(true);
+        setMsg('');
         try {
-            const res = await api.get('/admin/helpers', { params: { q, status, page: p, limit: l } });
+            const res = await api.get('/admin/helpers', {
+                params: { q, status, page: p, limit: l },
+            });
             setItems(res.data?.data || []);
             setMeta(res.data?.meta || { page: p, pages: 1, total: 0, limit: l });
-            setPage(res.data?.meta?.page || p);
-            setLimit(res.data?.meta?.limit || l);
         } catch (e) {
             setMsg(e?.response?.data?.error || 'Failed to load');
         } finally {
@@ -33,147 +38,219 @@ export default function HelpersAdmin() {
         }
     }
 
-    useEffect(() => { load(1, limit); /* eslint-disable-next-line */ }, []);
+    useEffect(() => {
+        load(1, limit); // initial load
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
-    // When filters change, start back at page 1
     function applyFilters() {
-        setPage(1);
         load(1, limit);
     }
 
-    async function createHelper(payload) {
-        try { await api.post('/admin/helpers', payload); setOpenForm(false); setEditing(null); await load(page, limit); }
-        catch (e) { alert(e?.response?.data?.error || 'Create failed'); }
-    }
-
-    async function updateHelper(id, payload) {
-        try { await api.put(`/admin/helpers/${id}`, payload); setOpenForm(false); setEditing(null); await load(page, limit); }
-        catch (e) { alert(e?.response?.data?.error || 'Update failed'); }
+    function changePageSize(e) {
+        const newLimit = Number(e.target.value) || 20;
+        load(1, newLimit);
     }
 
     async function removeHelper(id) {
         if (!confirm('Delete this helper?')) return;
         try {
             await api.delete(`/admin/helpers/${id}`);
-            // if we deleted the last item on the page, go back a page if possible
+            // if last item on page removed, go back a page
             const nextPage = items.length === 1 && page > 1 ? page - 1 : page;
-            setPage(nextPage);
             await load(nextPage, limit);
         } catch (e) {
             alert(e?.response?.data?.error || 'Delete failed');
         }
     }
 
-    // Pagination controls
-    const canPrev = page > 1;
-    const canNext = page < (meta.pages || 1);
-
-    const gotoFirst = () => { if (canPrev) { setPage(1); load(1, limit); } };
-    const gotoPrev = () => { if (canPrev) { setPage(page - 1); load(page - 1, limit); } };
-    const gotoNext = () => { if (canNext) { setPage(page + 1); load(page + 1, limit); } };
-    const gotoLast = () => { if (canNext) { setPage(meta.pages); load(meta.pages, limit); } };
-
-    function changeLimit(e) {
-        const newLimit = Number(e.target.value) || 20;
-        setLimit(newLimit);
-        setPage(1);
-        load(1, newLimit);
+    function openCreate() {
+        setOpenId(null);
+        setRefreshKey((k) => k + 1);
     }
 
+    function openEdit(id) {
+        setOpenId(id);
+        setRefreshKey((k) => k + 1);
+    }
+
+    function closeForm() {
+        setOpenId(undefined);
+    }
+
+    function onSaved() {
+        closeForm();
+        load(page, limit);
+    }
+
+    const gotoFirst = () => canPrev && load(1, limit);
+    const gotoPrev = () => canPrev && load(page - 1, limit);
+    const gotoNext = () => canNext && load(page + 1, limit);
+    const gotoLast = () => canNext && load(meta.pages, limit);
+
     return (
-        <div>
-            {/* Filters + actions */}
-            <div style={{ display: 'flex', gap: 8, marginBottom: 12, alignItems: 'center', flexWrap: 'wrap' }}>
+        <div className="space-y-4">
+            <h2 className="text-xl font-semibold">Helpers</h2>
+
+            {/* Filters */}
+            <div className="flex flex-wrap items-center gap-2">
                 <input
+                    className="border p-2 min-w-[220px]"
                     placeholder="Search name"
                     value={q}
-                    onChange={e => setQ(e.target.value)}
-                    style={{ minWidth: 220 }}
+                    onChange={(e) => setQ(e.target.value)}
                 />
-                <select value={status} onChange={e => setStatus(e.target.value)}>
+                <select
+                    className="border p-2"
+                    value={status}
+                    onChange={(e) => setStatus(e.target.value)}
+                >
                     <option value="">Any</option>
                     <option value="available">Available</option>
                     <option value="not">Not available</option>
                 </select>
-                <button onClick={applyFilters} disabled={loading}>{loading ? 'Loading…' : 'Search'}</button>
+                <button
+                    className="border px-3 py-2"
+                    onClick={applyFilters}
+                    disabled={loading}
+                >
+                    {loading ? 'Loading…' : 'Search'}
+                </button>
 
-                <div style={{ marginLeft: 'auto', display: 'flex', gap: 8, alignItems: 'center' }}>
+                <div className="ml-auto flex items-center gap-2">
                     <label>Page size:</label>
-                    <select value={limit} onChange={changeLimit}>
+                    <select
+                        className="border p-2"
+                        value={limit}
+                        onChange={changePageSize}
+                    >
                         <option value={10}>10</option>
                         <option value={20}>20</option>
                         <option value={50}>50</option>
                         <option value={100}>100</option>
                     </select>
-                    <button onClick={() => { setEditing(null); setOpenForm(true); }}>+ New Helper</button>
+                    <button
+                        className="bg-blue-600 text-white px-3 py-2 rounded"
+                        onClick={openCreate}
+                    >
+                        + New Helper
+                    </button>
                 </div>
             </div>
 
-            {msg && <p style={{ color: 'crimson' }}>{msg}</p>}
+            {msg && <div className="text-red-600">{msg}</div>}
 
             {/* Table */}
-            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-                <thead><tr>
-                    <th align="left">Name</th>
-                    <th align="left">Nationality</th>
-                    <th>Age</th>
-                    <th>Exp</th>
-                    <th>Skills</th>
-                    <th>Avail</th>
-                    <th>Salary</th>
-                    <th>Actions</th>
-                </tr></thead>
-                <tbody>
-                    {(items || []).map(h => (
-                        <tr key={h._id} style={{ borderTop: '1px solid #eee' }}>
-                            <td>{h.name}</td>
-                            <td>{h.nationality}</td>
-                            <td align="center">{h.age}</td>
-                            <td align="center">{h.experience}</td>
-                            <td>{Array.isArray(h.skills) ? h.skills.join(', ') : '-'}</td>
-                            <td align="center">{h.availability ? 'Yes' : 'No'}</td>
-                            <td align="center">{h.expectedSalary ?? '-'}</td>
-                            <td>
-                                <button
-                                    onClick={async () => {
-                                        const r = await api.get(`/admin/helpers/${h._id}`);
-                                        setEditing(r.data?.data);
-                                        setOpenForm(true);
-                                    }}
-                                >Edit</button>
-                                <button onClick={() => removeHelper(h._id)} style={{ marginLeft: 8 }}>Delete</button>
-                            </td>
+            <div className="overflow-x-auto">
+                <table className="w-full border-collapse">
+                    <thead>
+                        <tr className="[&>th]:text-left [&>th]:px-2 [&>th]:py-2 border-b">
+                            <th>Photo</th>
+                            <th>Name</th>
+                            <th>Nationality</th>
+                            <th className="text-center">Age</th>
+                            <th className="text-center">Exp</th>
+                            <th>Skills</th>
+                            <th className="text-center">Avail</th>
+                            <th className="text-center">Salary</th>
+                            <th>Actions</th>
                         </tr>
-                    ))}
-                    {!loading && (!items || items.length === 0) && (
-                        <tr>
-                            <td colSpan={8} style={{ padding: 12, color: '#666' }}>
-                                No helpers found.
-                            </td>
-                        </tr>
-                    )}
-                </tbody>
-            </table>
-
-            {/* Pagination footer */}
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 12 }}>
-                <button onClick={gotoFirst} disabled={!canPrev}>⏮ First</button>
-                <button onClick={gotoPrev} disabled={!canPrev}>◀ Prev</button>
-                <span style={{ opacity: .8 }}>
-                    Page <b>{meta.page || 1}</b> of <b>{meta.pages || 1}</b>
-                    {typeof meta.total === 'number' ? <> • Total: <b>{meta.total}</b></> : null}
-                </span>
-                <button onClick={gotoNext} disabled={!canNext}>Next ▶</button>
-                <button onClick={gotoLast} disabled={!canNext}>Last ⏭</button>
+                    </thead>
+                    <tbody>
+                        {(items || []).map((h) => (
+                            <tr key={h._id} className="border-b hover:bg-gray-50">
+                                <td className="px-2 py-2">
+                                    {Array.isArray(h.photos) && h.photos[0] ? (
+                                        <img
+                                            src={h.photos[0]}
+                                            alt=""
+                                            style={{ width: 40, height: 40, objectFit: 'cover', borderRadius: 4 }}
+                                        />
+                                    ) : (
+                                        <img
+                                            src="/placeholder-helper.png"
+                                            alt=""
+                                            style={{ width: 40, height: 40, objectFit: 'cover', borderRadius: 4, opacity: 0.85 }}
+                                        />
+                                    )}
+                                </td>
+                                <td className="px-2 py-2">{h.name}</td>
+                                <td className="px-2 py-2">{h.nationality}</td>
+                                <td className="px-2 py-2 text-center">{h.age}</td>
+                                <td className="px-2 py-2 text-center">{h.experience}</td>
+                                <td className="px-2 py-2">{Array.isArray(h.skills) ? h.skills.join(', ') : '-'}</td>
+                                <td className="px-2 py-2 text-center">{h.availability ? 'Yes' : 'No'}</td>
+                                <td className="px-2 py-2 text-center">{h.expectedSalary ?? '-'}</td>
+                                <td className="px-2 py-2">
+                                    <button
+                                        className="px-2 py-1 border rounded"
+                                        onClick={() => openEdit(h._id)}
+                                    >
+                                        Edit
+                                    </button>
+                                    <button
+                                        className="px-2 py-1 border rounded ml-2"
+                                        onClick={() => removeHelper(h._id)}
+                                    >
+                                        Delete
+                                    </button>
+                                </td>
+                            </tr>
+                        ))}
+                        {!loading && (!items || items.length === 0) && (
+                            <tr>
+                                <td className="px-2 py-4 text-gray-600" colSpan={9}>
+                                    No helpers found.
+                                </td>
+                            </tr>
+                        )}
+                    </tbody>
+                </table>
             </div>
 
-            {/* Create/Edit modal */}
-            <HelperForm
-                open={openForm}
-                initial={editing}
-                onClose={() => { setOpenForm(false); setEditing(null); }}
-                onSubmit={(payload) => editing ? updateHelper(editing._id, payload) : createHelper(payload)}
-            />
+            {/* Pagination */}
+            <div className="flex items-center gap-2">
+                <button className="border px-2 py-1" onClick={gotoFirst} disabled={!canPrev}>
+                    ⏮ First
+                </button>
+                <button className="border px-2 py-1" onClick={gotoPrev} disabled={!canPrev}>
+                    ◀ Prev
+                </button>
+                <span className="opacity-80">
+                    Page <b>{meta.page || 1}</b> of <b>{meta.pages || 1}</b>
+                    {typeof meta.total === 'number' ? (
+                        <> • Total: <b>{meta.total}</b></>
+                    ) : null}
+                </span>
+                <button className="border px-2 py-1" onClick={gotoNext} disabled={!canNext}>
+                    Next ▶
+                </button>
+                <button className="border px-2 py-1" onClick={gotoLast} disabled={!canNext}>
+                    Last ⏭
+                </button>
+            </div>
+
+            {/* Modal */}
+            {openId !== undefined && (
+                <div className="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-50">
+                    <div className="bg-white rounded shadow-xl p-4 max-w-2xl w-full">
+                        <div className="flex items-center justify-between mb-2">
+                            <h3 className="text-lg font-semibold">
+                                {openId ? 'Edit Helper' : 'Create Helper'}
+                            </h3>
+                            <button className="text-gray-600" onClick={closeForm}>
+                                ✕
+                            </button>
+                        </div>
+                        <HelperForm
+                            key={refreshKey}
+                            helperId={openId || undefined}
+                            onSaved={onSaved}
+                        />
+                    </div>
+                </div>
+            )}
         </div>
     );
 }
+


### PR DESCRIPTION
## Summary
- replace admin helpers page with modal-based management, including photo column and edit/create actions
- support removing existing photos in helper form for updates

## Testing
- `npm test --prefix client` *(fails: Missing script "test")*
- `npm run lint --prefix client`
- `npm test --prefix server` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b1397df9788328a44cd51a2be279fd