### PR TITLE
feat: allow closing helper modal with Escape key

### DIFF
--- a/client/src/pages/admin/HelpersAdmin.jsx
+++ b/client/src/pages/admin/HelpersAdmin.jsx
@@ -95,6 +95,16 @@ export default function HelpersAdmin() {
         load(page, limit);
     }
 
+    // close the modal when pressing the Escape key
+    useEffect(() => {
+        if (openId === undefined) return;
+        function handleKey(e) {
+            if (e.key === 'Escape') closeForm();
+        }
+        window.addEventListener('keydown', handleKey);
+        return () => window.removeEventListener('keydown', handleKey);
+    }, [openId]);
+
     const gotoFirst = () => canPrev && load(1, limit);
     const gotoPrev = () => canPrev && load(page - 1, limit);
     const gotoNext = () => canNext && load(page + 1, limit);


### PR DESCRIPTION
## Summary
- allow closing the helper edit/create modal with the Escape key
- keep edit operations in a modal pop-up instead of inline

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b15e54d7108328b2c16b719bdd757f