### PR TITLE
Place helper editor modal at top-right

### DIFF
--- a/client/src/pages/admin/HelpersAdmin.jsx
+++ b/client/src/pages/admin/HelpersAdmin.jsx
@@ -255,7 +255,7 @@ export default function HelpersAdmin() {
             {/* Modal */}
             {openId !== undefined && (
                 <div
-                    className="fixed inset-0 bg-black/40 flex items-center justify-center p-4 z-50"
+                    className="fixed inset-0 bg-black/40 flex items-start justify-end p-4 z-50"
                     onClick={closeForm}
                 >
                     <div


### PR DESCRIPTION
## Summary
- Reposition helper edit/create modal to top-right using flex alignment

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b1652770c08328a902e7cbb646328f