### PR TITLE
Fix edit modal not opening in helpers admin

### DIFF
--- a/client/src/pages/admin/HelpersAdmin.jsx
+++ b/client/src/pages/admin/HelpersAdmin.jsx
@@ -1,5 +1,5 @@
 // client/src/pages/admin/HelpersAdmin.jsx
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import api from '../../api';
 import HelperForm from './HelperForm.jsx';
@@ -18,10 +18,14 @@ export default function HelpersAdmin() {
     const [openId, setOpenId] = useState(undefined);
     const [refreshKey, setRefreshKey] = useState(0); // force re-mount of form
 
-    // Portal target with safe fallback
-    const portalTarget = useMemo(() => {
-        if (typeof document === 'undefined') return null;
-        return document.getElementById('portal-root') || document.body;
+    // Portal target set after mount to support SSR
+    const [portalTarget, setPortalTarget] = useState(null);
+    useEffect(() => {
+        if (typeof document !== 'undefined') {
+            setPortalTarget(
+                document.getElementById('portal-root') || document.body
+            );
+        }
     }, []);
 
     // lock body scroll when modal is open


### PR DESCRIPTION
## Summary
- ensure portal target initializes after mount so edit modal renders correctly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1722c3634832890822d471d49bdcd